### PR TITLE
Fix typo in min validation message

### DIFF
--- a/src/lib/es.js
+++ b/src/lib/es.js
@@ -29,7 +29,7 @@ export const mixed = {
 };
 export const string = {
     length: '${path} debe ser exactamente ${length} caracteres',
-    min: '${path} debe ser de al menos ${min}caracteres',
+    min: '${path} debe ser de al menos ${min} caracteres',
     max: '${path} debe ser como máximo ${max} caracteres',
     matches: '${path} debe coincidir con el siguiente: "${regex}"',
     email: '${path} debe ser un correo electrónico válido',


### PR DESCRIPTION
Added the missing space between the `min` placeholder and the validation message.

BTW thank you for creating this; I was about to do the translation manually 🤘🏻.